### PR TITLE
Frontend refactor with central API and improved auth

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,10 @@
-import { AuthProvider, useAuth } from './AuthContext';
-import ButtonCheck from './ButtonCheck';
-import LoginForm from './LoginForm';
+import React from "react";
+import { AuthProvider, useAuth } from "./AuthContext";
+import ButtonCheck from "./ButtonCheck";
+import LoginForm from "./LoginForm";
 
-function Inner() {
+const Greeting: React.FC = () => {
   const { user, logout } = useAuth();
-
-   if (!user) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white gap-6">
-        <LoginForm />
-        <ButtonCheck />
-      </div>
-    );
-  }
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white gap-6">
       <h1 className="text-3xl font-bold">Привет, {user}!</h1>
@@ -24,6 +16,19 @@ function Inner() {
       </button>
     </div>
   );
+};
+
+function Inner() {
+  const { user } = useAuth();
+  if (!user) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white gap-6">
+        <LoginForm />
+        <ButtonCheck />
+      </div>
+    );
+  }
+  return <Greeting />;
 }
 
 export default function App() {
@@ -33,3 +38,4 @@ export default function App() {
     </AuthProvider>
   );
 }
+

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -1,20 +1,20 @@
-import { useState } from 'react';
-import { useAuth } from './AuthContext';
+import React, { useState } from "react";
+import { useAuth } from "./AuthContext";
 
 const MIN_LEN = 4;
 
 export default function LoginForm() {
   const { login, register } = useAuth();
-  const [mode, setMode] = useState<'login' | 'register'>('login');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const isValid = username.length >= MIN_LEN && password.length >= MIN_LEN;
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();password
+    e.preventDefault();
     if (!isValid) {
       setError(`Минимум ${MIN_LEN} символа`);
       return;
@@ -22,19 +22,14 @@ export default function LoginForm() {
     setLoading(true);
     setError(null);
 
-    let ok = false;
-    if (mode === 'login') {
-      ok = await login(username, password);
-    } else {
-      const registered = await register(username, password);
-      if (registered) ok = await login(username, password);
-    }
+    const ok =
+      mode === "login"
+        ? await login(username, password)
+        : await register(username, password);
 
     if (!ok) {
       setError(
-        mode === 'login'
-          ? 'Неверный логин или пароль'
-          : 'Не удалось зарегистрировать'
+        mode === "login" ? "Неверный логин или пароль" : "Не удалось зарегистрировать"
       );
     }
     setLoading(false);
@@ -43,56 +38,47 @@ export default function LoginForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="w-full max-w-sm bg-gray-800 p-6 rounded-2xl shadow-lg flex flex-col gap-4"
+      className="w-full max-w-xs bg-gray-800 p-6 rounded-lg shadow-lg flex flex-col gap-4"
     >
-      <h2 className="text-xl font-semibold text-center">
-        {mode === 'login' ? 'Войти' : 'Создать аккаунт'}
+      <h2 className="text-2xl font-bold text-center">
+        {mode === "login" ? "Авторизация" : "Регистрация"}
       </h2>
 
+      {error && <p className="text-red-400 text-center">{error}</p>}
+
       <input
-        className="px-3 py-2 rounded bg-gray-700 outline-none focus:ring-2 focus:ring-blue-500"
-        placeholder="username"
         value={username}
         onChange={(e) => setUsername(e.target.value)}
+        placeholder="Логин"
+        className="p-2 rounded text-black"
       />
       <input
-        className="px-3 py-2 rounded bg-gray-700 outline-none focus:ring-2 focus:ring-blue-500"
         type="password"
-        placeholder="Пароль"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
+        placeholder="Пароль"
+        className="p-2 rounded text-black"
       />
 
-      {error && (
-        <p className="text-sm text-red-500 text-center whitespace-pre-line">
-          {error}
-        </p>
-      )}
-
       <button
-        className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-semibold py-2 px-4 rounded shadow"
         type="submit"
         disabled={!isValid || loading}
+        className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 px-4 py-2 rounded shadow"
       >
-        {loading
-          ? '...'
-          : mode === 'login'
-          ? 'Войти'
-          : 'Зарегистрироваться'}
+        {loading ? "…" : mode === "login" ? "Войти" : "Создать аккаунт"}
       </button>
 
       <p className="text-sm text-center">
-        {mode === 'login' ? 'Нет аккаунта? ' : 'Уже есть аккаунт? '}
+        {mode === "login" ? "Нет аккаунта? " : "Уже есть аккаунт? "}
         <button
           type="button"
           className="text-blue-400 underline"
-          onClick={() =>
-            setMode(mode === 'login' ? 'register' : 'login')
-          }
+          onClick={() => setMode(mode === "login" ? "register" : "login")}
         >
-          {mode === 'login' ? 'Создать' : 'Войти'}
+          {mode === "login" ? "Создать" : "Войти"}
         </button>
       </p>
     </form>
   );
 }
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,20 @@
+export const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
+export async function request<T>(
+  url: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${url}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+  return (await res.json()) as T;
+}
+

--- a/frontend/src/vite.config.ts
+++ b/frontend/src/vite.config.ts
@@ -1,27 +1,15 @@
-import { defineConfig, loadEnv } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-// В dev-режиме Vite сам проксирует /api → localhost:5000.
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd());
-  return {
-    plugins: [react()],
-    define: {
-      // пробрасываем базовый URL API в рантайм (для fetch'ей и т.д.)
-      __API__: JSON.stringify(env.VITE_API_BASE_URL || 'http://localhost:5000')
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/auth": {
+        target: process.env.VITE_API_BASE ?? "http://93.81.237.94:1111",
+        changeOrigin: true,
+      },
     },
-    server: {
-      port: 5173,
-      proxy: {
-        '/api': env.VITE_API_BASE_URL || 'http://localhost:5000',
-        // В дев-режиме кнопка шлёт `GET /check` → проксируем так же,
-        // чтобы код не отличался между dev и prod.
-        '/check': env.VITE_API_BASE_URL || 'http://localhost:5000'
-      }
-    },
-    build: {
-      outDir: 'dist',
-      emptyOutDir: true
-    }
-  };
+  },
 });
+


### PR DESCRIPTION
## Summary
- add typed `api.ts` helper around fetch
- improve JWT handling and memoize auth context
- clean up login form and auth logic
- proxy `/auth` API requests in vite server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684eaeccbdf48322ad87c16394146620